### PR TITLE
RFC: Resync weight

### DIFF
--- a/crp/contracts/ConfigurableRightsPool.sol
+++ b/crp/contracts/ConfigurableRightsPool.sol
@@ -399,6 +399,20 @@ contract ConfigurableRightsPool is PCToken, BalancerOwnable, BalancerReentrancyG
         _pushPoolShare(msg.sender, initialSupply);
     }
 
+    function resyncWeight(address token)
+        external
+        _logs_
+        _lock_
+        _onlyOwner_
+        _needsBPool_
+    {
+        require(_rights.canChangeWeights, "ERR_NOT_CONFIGURABLE_WEIGHTS");
+
+        require(_startBlock == 0, "ERR_NO_UPDATE_DURING_GRADUAL");
+
+        SmartPoolManager.resyncWeight(this, bPool, token);
+    }
+
     /**
      * @notice Update the weight of an existing token
      * @dev Notice Balance is not an input (like with rebind on BPool) since we will require prices not to change

--- a/crp/contracts/IBFactory.sol
+++ b/crp/contracts/IBFactory.sol
@@ -13,6 +13,7 @@ interface IBPool {
     function unbind(address token) external;
     function getDenormalizedWeight(address token) external view returns (uint);
     function getTotalDenormalizedWeight() external view returns (uint);
+    function gulp(address token) external;
 
     function calcPoolOutGivenSingleIn(
         uint tokenBalanceIn,


### PR DESCRIPTION
Implemented a version of `gulp` which does not change price. This could lie as part of `BPool`; however, for now, it's part of CRP. This could support integrations with elastic tokens.

Also handles a corner case; (eg) consider 50-50 USDC and DAI pool, IF someone transfers dai into the bPool and calls gulp price changes. However `resyncWeight` would alter weight proportionally so that price remains the same